### PR TITLE
qcom: Mark some gralloc bits as valid

### DIFF
--- a/config/BoardConfigQcom.mk
+++ b/config/BoardConfigQcom.mk
@@ -43,6 +43,15 @@ ifeq ($(call is-board-platform-in-list, $(UM_4_9_FAMILY)),true)
     TARGET_USES_DRM_PP := true
 endif
 
+# Mark GRALLOC_USAGE_PRIVATE_WFD as valid gralloc bits
+TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS ?= 0
+TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS += | (1 << 21)
+
+# Mark GRALLOC_USAGE_PRIVATE_10BIT_TP as valid gralloc bits on UM platforms that support it
+ifeq ($(call is-board-platform-in-list, $(UM_4_9_FAMILY)),true)
+    TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS += | (1 << 27)
+endif
+
 # List of targets that use master side content protection
 MASTER_SIDE_CP_TARGET_LIST := msm8996 msm8998 sdm660 sdm845
 


### PR DESCRIPTION
 * Add GRALLOC_USAGE_PRIVATE_WFD as valid gralloc bits for all
   the platforms and GRALLOC_USAGE_PRIVATE_10BIT_TP only for the
   UM 4.9-based platforms. Both are defined in the respective
   display HALs (in gralloc/gralloc_priv.h) being the latter
   only available for sdm845.

 * This results in the same as applying https://goo.gl/SR7sFY,
   but it's preferable since it makes use of our own method of
   extending the valid gralloc 1.0 usage bits (see commit 59009f8).
   TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS is extended here on
   purpose and as a bitwise OR of all the values in order not to
   clear what might have been set in the device trees.

Change-Id: I5536f341e75088cc72ac369065011388f0a6d3f1
Signed-off-by: Akhil Narang <akhilnarang.1999@gmail.com>